### PR TITLE
Adding capability to load settings.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,35 @@ To restore a file from AWS S3, you need to run the below command.
 * `LOG_DEBUG` (default `0`)
 
   Set to `1` if debug lines are to be logged (to console or syslog)
+
+## Config file
+
+The above environment variables can be defined in a file and be mounted in as shown in the below example. The path has
+to be `/app/settings.env` within the container.
+
+    # settings.env
+    SOURCE_FILE_PATTERN='*.zip'
+    SOURCE_REMOVE_PLAIN=1
+    GPG_PASSPHRASE=xxxx-PASSWORD-xxxx
+    AWS_ACCESS_KEY=__AWS_ACCESS_KEY__
+    AWS_SECRET_KEY=__AWS_SECRET_KEY__
+    AWS_S3_BUCKET=__AWS_S3_BUCKET__
+    AWS_S3_BUCKET_PATH=__AWS_S3_BUCKET_PATH__
+
+Docker commands can be as below.
+
+    docker run \
+        -v /path/to/settings.env:/app/settings.env \
+        -v /path/to/plain-files-dir:/data/plain \
+        -v /path/to/encrypted-files-dir:/data/encrypted \
+        redmatter/gpg-s3sync
+
+    docker run \
+        -v /path/to/settings.env:/app/settings.env \
+        -v /path/to/plain-files-dir:/data/plain \
+        -v /path/to/encrypted-files-dir:/data/encrypted \
+        redmatter/gpg-s3sync restore file-name.zip.gpg
+
+## License
+
+This code is licensed under MIT license. See [LICENSE](LICENSE) for more details.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ source /app/functions.sh
 source /app/gpgcrypt.sh
 source /app/s3sync.sh
 
+load_settings_file
 set_debug
 
 : ${SOURCE_REMOVE_PLAIN:=0}

--- a/functions.sh
+++ b/functions.sh
@@ -4,6 +4,7 @@
 : ${SYSLOG_FACILITY:=local0}
 : ${DEBUG:=0}
 : ${LOG_DEBUG:=0}
+: ${SETTINGS_FILE:=/app/settings.env}
 
 if [ -n "$SYSLOG_TAG" ]; then
     log_pipe=/tmp/bash_log_pipe_$(date +%s)_${RANDOM}.tmp
@@ -74,6 +75,14 @@ fn_exists() {
 # check if the given value is not empty and is a number
 is_number() {
     [ "$1" -eq "$1" ] &>/dev/null
+}
+
+load_settings_file() {
+    if [ -f "${SETTINGS_FILE}" ]; then
+        set -a
+        source "${SETTINGS_FILE}"
+        set +a
+    fi
 }
 
 check_command logger


### PR DESCRIPTION
@lejambon and @abulford 
Please review this; writing systemd unit file is much easier with this; otherwise all environment vars has to be listed in the unit file itself.
