### PR TITLE
Fix shared-volume permission issue(s)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@ LICENSE
 README.md
 docker-compose.test.yml
 run-test.sh
+Dockerfile*
+.git
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM debian:jessie
 
-ENV SOURCE_PATH=/data/plain \
-    ENCRYPTED_PATH=/data/encrypted \
-    GNUPGHOME=/app/.gnupg
+ENV GNUPGHOME=/app/.gnupg
 
 COPY * /app/
 
@@ -18,12 +16,12 @@ RUN ( \
     apt-get update; \
     apt-get install --no-install-recommends -y $BUILD_DEPS $APP_DEPS ; \
 
-    for path in $SOURCE_PATH $ENCRYPTED_PATH $GNUPGHOME; do \
-        mkdir -p $path && chmod go-rwx $path; \
-    done; \
+    # If this container is run as any user other than root, GNUPGHOME would need different ownership. At run time this
+    # can to an extend be resolved by using a 'tmpfs' mount, which can take 'uid' option.
+    mkdir -p "$GNUPGHOME" && chmod go-rwx "$GNUPGHOME"; \
 
     # remove packages that we don't need
-    apt-get remove -y $BUILD_DEPS ; \
+    [ -z "$BUILD_DEPS" ] || apt-get remove -y $BUILD_DEPS; \
     apt-get autoremove -y ; \
     apt-get clean; \
     rm -rf /var/lib/apt/* /var/lib/dpkg/* /var/lib/cache/* /var/lib/log/*; \

--- a/Dockerfile.test-data-generator
+++ b/Dockerfile.test-data-generator
@@ -16,8 +16,8 @@ RUN ( \
     # In the test setup (ref: docker-compose.test.yml), the 'sut' service which is mocking the gpg-s3sync functionality
     # is run as root. This can be changed if you extend the base image or by adding USER directive to the Dockerfile
     mkdir -p "$DATA_PATH" && \
-    chown daemon:daemon "$DATA_PATH"; \
-    chmod go-rwx "$DATA_PATH" && \
+        chown daemon:daemon "$DATA_PATH" && \
+        chmod go-rwx "$DATA_PATH"; \
 
     # In order to satisfy check_command checks; these commands are not used by the data-generator
     ln -s /bin/true /bin/s3cmd; \

--- a/Dockerfile.test-data-generator
+++ b/Dockerfile.test-data-generator
@@ -1,0 +1,29 @@
+FROM debian:jessie
+
+# DATA_PATH is the path where data is generated into. This would be a shared location (via volume) from where
+# gpg-s3sync would read data from.
+ENV DATA_PATH=/data/plain
+
+COPY * /app/
+
+RUN ( \
+    # Here we are trying to emulate a real world scenario where a container that generates some data needing backup.
+    # In that case, the container can dictate what user it is run as; in this case we are using 'daemon' user.
+    #
+    # In this case, the data generator app has decided to have the path under /data/plain and have no read/write perms
+    # for anyone other than the daemon user.
+    #
+    # In the test setup (ref: docker-compose.test.yml), the 'sut' service which is mocking the gpg-s3sync functionality
+    # is run as root. This can be changed if you extend the base image or by adding USER directive to the Dockerfile
+    mkdir -p "$DATA_PATH" && \
+    chown daemon:daemon "$DATA_PATH"; \
+    chmod go-rwx "$DATA_PATH" && \
+
+    # In order to satisfy check_command checks; these commands are not used by the data-generator
+    ln -s /bin/true /bin/s3cmd; \
+    ln -s /bin/true /bin/awk; \
+)
+
+# As mentioned above, this image is setup to be run as daemon:daemon. This is not altered in docker-compose.test.yml
+# using the "user:" directive.
+USER daemon:daemon

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,30 +1,49 @@
 version: "2"
 services:
-  debug:
-    image: busybox
-    command: sh
+  test-data-generator:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-data-generator
+    entrypoint: /run-test.sh
+    command:
+      - create_test_files
+      # up / run docker-compose with "wait_after_create_test_files=yes" to make test-data-generator wait; this is to
+      # emulate a long running data-generation container, from which gpg-s3sync will perform backup
+      - ${wait_after_create_test_files}
     volumes:
       - data:/data/plain
-      - encrypted-data:/data/encrypted
+      - ./run-test.sh:/run-test.sh
+    environment:
+      - SOURCE_PATH=/data/plain
+      - DEBUG=${BASH_DEBUG}
+      - LOG_DEBUG=${DEBUG}
 
   sut:
     build: .
     entrypoint: /run-test.sh
+    command: run_test
+    depends_on:
+      - test-data-generator
     volumes:
+      # Mount the data to be backed-up into a path that does not exist in the gpg-s3sync image. Otherwise docker volume
+      # side-effects will come into play, replacing permissions etc. affecting the data-generator
       - data:/data/plain
       - encrypted-data:/data/encrypted
       - ./run-test.sh:/run-test.sh
     environment:
-      - DEBUG=${BASH_DEBUG}
-      - LOG_DEBUG=${DEBUG}
+      - SOURCE_PATH=/data/plain
+      - ENCRYPTED_PATH=/data/encrypted
       - GPG_PASSPHRASE=topsecret
+      # Specify these S3 values in the environment (on CLI) in order to test that call-flow
       - AWS_ACCESS_KEY=${ACCESS_KEY}
       - AWS_SECRET_KEY=${SECRET_KEY}
       - AWS_S3_BUCKET=${BUCKET}
       - AWS_S3_BUCKET_PATH=/backups/
-      - SOURCE_REMOVE_PLAIN=1
+      - SOURCE_REMOVE_PLAIN=0
       - SOURCE_FILE_MODIFIED_MINUTES_AGO=0
       - SOURCE_FILE_PATTERN=*.txt
+      - DEBUG=${BASH_DEBUG}
+      - LOG_DEBUG=${DEBUG}
 
 volumes:
   data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,17 +18,22 @@ set_debug
 : "${SOURCE_PATH:=/data/plain}"
 : "${ENCRYPTED_PATH:=/data/encrypted}"
 
+get_path_info() {
+    stat -c '%U:%G %A %N' "$1"; return 0
+}
+
 backup() {
     # source-path must be a directory and be readable and searchable
     test_all drx "${SOURCE_PATH}" ||
-        bail "Cannot read from source-path (SOURCE_PATH='$SOURCE_PATH' $(stat -c %A "${SOURCE_PATH}"))"
+        bail "Cannot read from source-path (SOURCE_PATH: $(get_path_info "${SOURCE_PATH}"))"
     # if plain file is to be removed after 'backup', source-path must be writable
     ( [ "${SOURCE_REMOVE_PLAIN}" = 0 ] || [ -w "${SOURCE_PATH}" ] ) || {
-        bail "Cannot write to source-path (Cannot remove plain file; SOURCE_REMOVE_PLAIN='$SOURCE_REMOVE_PLAIN', SOURCE_PATH='${SOURCE_PATH}' $(stat -c %A "${SOURCE_PATH}"))"
+        bail "Cannot write to source-path (Cannot remove plain file; SOURCE_REMOVE_PLAIN='$SOURCE_REMOVE_PLAIN'," \
+            "SOURCE_PATH: $(get_path_info "${SOURCE_PATH}"))"
     }
     # destination/encrypted-path must be a directory and be writable and searchable
     test_all drwx "${ENCRYPTED_PATH}" ||
-        bail "Cannot write to encrypted-path (ENCRYPTED_PATH=${ENCRYPTED_PATH})"
+        bail "Cannot write to encrypted-path (ENCRYPTED_PATH: $(get_path_info "${ENCRYPTED_PATH}"))"
 
     local all_backups=( $(list-backups --batch-mode) )
 
@@ -70,10 +75,10 @@ restore() {
 
     # destination/encrypted-path must be a directory and be readable and searchable
     test_all drx "${ENCRYPTED_PATH}" ||
-        bail "Cannot read from encrypted-path (ENCRYPTED_PATH='${ENCRYPTED_PATH}' $(stat -c %A "${ENCRYPTED_PATH}"))"
+        bail "Cannot read from encrypted-path (ENCRYPTED_PATH: $(get_path_info "${ENCRYPTED_PATH}"))"
     # source-path to which the file is restored, must be a directory and be writable and searchable
     test_all drwx "${SOURCE_PATH}" ||
-        bail "Cannot write to source-path (SOURCE_PATH='$SOURCE_PATH' $(stat -c %A "${SOURCE_PATH}"))"
+        bail "Cannot write to source-path (SOURCE_PATH: $(get_path_info "${SOURCE_PATH}"))"
 
     local gpg_file="$ENCRYPTED_PATH/$1"
 
@@ -85,7 +90,7 @@ restore() {
         if s3sync is_enabled; then
             # Inorder for sync-down to work, the encrypted path must be writable
             [ -w "${ENCRYPTED_PATH}" ] ||
-                bail "Cannot write to encrypted-path (ENCRYPTED_PATH='${ENCRYPTED_PATH}' $(stat -c %A "${ENCRYPTED_PATH}"))"
+                bail "Cannot write to encrypted-path (ENCRYPTED_PATH='${ENCRYPTED_PATH}' $(get_path_info "${ENCRYPTED_PATH}"))"
 
             debug "Syncing down from ${AWS_S3_BUCKET}/${AWS_S3_BUCKET_PATH} ... $*"
             s3sync down "$@"
@@ -105,10 +110,10 @@ restore() {
 list-backups() {
     # source-path must be a directory and be readable and searchable
     test_all drx "${SOURCE_PATH}" ||
-        bail "Source path could not be found (SOURCE_PATH='$SOURCE_PATH' $(stat -c %A "${SOURCE_PATH}"))"
+        bail "Source path could not be found (SOURCE_PATH: $(get_path_info "${SOURCE_PATH}"))"
     # destination/encrypted-path must be a directory and be readable and searchable
     test_all drx "${ENCRYPTED_PATH}" ||
-        bail "Encrypted path could not be found (ENCRYPTED_PATH='${ENCRYPTED_PATH}' $(stat -c %A "${ENCRYPTED_PATH}"))"
+        bail "Encrypted path could not be found (ENCRYPTED_PATH: $(get_path_info "${ENCRYPTED_PATH}"))"
 
     local batch_mode=$([[ "$1" = "--batch-mode" ]] && echo true || echo false)
     local files_in_s3=();
@@ -143,8 +148,8 @@ list-backups() {
 # Quit if the AWS S3 config values are improperly specified
 s3sync is_enabled || info "AWS S3 sync not enabled"
 
-info "SOURCE_PATH: '$SOURCE_PATH' $(stat -c %A "${SOURCE_PATH}")"
-info "ENCRYPTED_PATH: '$ENCRYPTED_PATH' $(stat -c %A "${ENCRYPTED_PATH}")"
+info "SOURCE_PATH: $(get_path_info "${SOURCE_PATH}")"
+info "ENCRYPTED_PATH: $(get_path_info "${ENCRYPTED_PATH}")"
 
 cmd="$1"; shift
 case "$cmd" in

--- a/functions.sh
+++ b/functions.sh
@@ -89,6 +89,26 @@ load_settings_file() {
     fi
 }
 
+# Test all specified bash tests
+#
+# E.g: test_all dxw /tmp
+#      Is the same as writing [ -d /tmp -a -x /tmp -a -w /tmp ]
+test_all() {
+    [ -n "$1" -a -n "$2" ] || bail "Invalid invocation of 'test_all'";
+
+    # explode each test
+    local tests=( $(echo "$1" | fold -w1) )
+
+    # stitch together the command array
+    local cmd=( "-${tests[@]:0:1}" "$2" )
+    for ((i=1; i <= ${#tests}; i++)); do
+        cmd+=( -a "-${tests[$i]}" "$2" )
+    done
+
+    # evaluate the command
+    [ "${cmd[@]}" ]
+}
+
 # in_array - check if an element can be found in an array
 #
 # This will work in most cases though as the "haystack" is passed in as arguments

--- a/gpgcrypt.sh
+++ b/gpgcrypt.sh
@@ -20,7 +20,7 @@ gpg() {
             gpg_path="${path}.gpg";
             debug "encrypt: Destination path not specified; encrypting to '$gpg_path'"
         elif [ -d "$1" ]; then
-            gpg_path="$1/$(basename "$gpg_path")"; shift
+            gpg_path="$1/$(basename "$path").gpg"; shift
             debug "encrypt: Destination path is a directory; encrypting to '$gpg_path'"
         else
             gpg_path="$1"; shift

--- a/run-test.sh
+++ b/run-test.sh
@@ -80,6 +80,14 @@ run_test() {
             local filepath="${SOURCE_PATH}/data-$(printf '%02d' "$i").txt"
             local filename=$(basename "$filepath")
 
+            # Using one file from the above set of tests, which has already been restored into SOURCE_PATH, check if
+            # the restore will fail if the destination file already exists. If the command succeeds, i.e the file was
+            # overwritten, then it is treated as a failure.
+            if /app/entrypoint.sh restore "${filename}.gpg"; then
+                error "File in SOURCE_PATH overwritten!"
+                return 1;
+            fi
+
             # remove the file before restore; otherwise 'restore' will bail seeing the file
             rm -f "$filepath";
 
@@ -93,14 +101,6 @@ run_test() {
             /app/entrypoint.sh restore "${filename}.gpg"
             verify_test_file "$filename"
         done
-
-        # Using one file from the above set of tests, which has already been restored into SOURCE_PATH, check if the
-        # restore will fail if the destination file already exists. If the command succeeds, i.e the file was
-        # overwritten, then it is treated as a failure.
-        if /app/entrypoint.sh restore "data-01.txt.gpg"; then
-            error "File in SOURCE_PATH overwritten!"
-            return 1;
-        fi
     fi
 
     return 0;
@@ -108,9 +108,6 @@ run_test() {
 
 cmd="$1"; shift
 case "$cmd" in
-    wait)
-        while true; do sleep 1; done;
-        ;;
     run_test|create_test_files|cleanup)
         "$cmd" "$@"
         ;;

--- a/run-test.sh
+++ b/run-test.sh
@@ -80,9 +80,8 @@ run_test() {
             local filepath="${SOURCE_PATH}/data-$(printf '%02d' "$i").txt"
             local filename=$(basename "$filepath")
 
-            # Using one file from the above set of tests, which has already been restored into SOURCE_PATH, check if
-            # the restore will fail if the destination file already exists. If the command succeeds, i.e the file was
-            # overwritten, then it is treated as a failure.
+            # Check if the restore will fail if the destination file already exists. If the command succeeds, i.e the
+            # file was overwritten, then it is treated as a failure.
             if /app/entrypoint.sh restore "${filename}.gpg"; then
                 error "File in SOURCE_PATH overwritten!"
                 return 1;

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-: ${SOURCE_REMOVE_PLAIN:=0}
-: ${SOURCE_PATH:=/data/plain}
-: ${ENCRYPTED_PATH:=/data/encrypted}
+: "${SOURCE_REMOVE_PLAIN:=0}"
+: "${SOURCE_PATH:=/data/plain}"
+: "${ENCRYPTED_PATH:=/data/encrypted}"
 
 source /app/functions.sh
 source /app/s3sync.sh
@@ -11,55 +11,110 @@ set_debug
 
 set -e
 
+n_files=10
+
+cleanup() {
+    local path="$1"; shift
+    info "Cleaning up $path ..."
+    find "$path" -mindepth 1 -maxdepth 1 -type f -delete
+}
+
 create_test_files() {
+    debug "SOURCE_PATH: $(ls -ld "${SOURCE_PATH}")"
+
+    cleanup "${SOURCE_PATH}"
+
     md5sums="${SOURCE_PATH}/data.md5sums"
     file_exists "$md5sums" && rm "$md5sums"
-    for i in $(seq 1 10); do
-        local file="${SOURCE_PATH}/data-$(printf %02d $i).txt"
-        dd if=/dev/urandom of=$file bs=1M count=1 &>/dev/null
-        md5sum "$file" >> "$md5sums"
+    for i in $(seq 1 "$n_files"); do
+        local file="${SOURCE_PATH}/data-$(printf %02d "$i").txt"
+        debug "Creating '$file'"
+        dd if=/dev/urandom of="$file" bs=100K count=1 &>/dev/null ||
+            bail "Failed to create '$file'"
+        # cd into the location before generating the MD5 so that path change wouldn't affect verify later on
+        ( cd "$(dirname "$file")" && md5sum "$(basename "$file")" >> "$md5sums" )
+    done
+
+    # For debug purpose pass additional arg ('yes' or '1') to create_test_files
+    # Plumbed in via the docker-compose.test.yml by honoring the env var 'wait_after_create_test_files'
+    #
+    # Example invocation:
+    #   wait_after_create_test_files=yes docker-compose -f docker-compose.test.yml up
+    while [[ "$1" = '1' || "$1" = 'yes' ]]; do
+        sleep 1;
+        ls -ld "${SOURCE_PATH}";
     done
 }
 
 verify_test_file() {
     local pattern="$1"; shift
-    md5sum -c <(grep "$pattern" "${SOURCE_PATH}/data.md5sums")
+    (
+        cd "$SOURCE_PATH" && md5sum -c <(grep "$pattern" "data.md5sums")
+    )
 }
 
-run() {
-    create_test_files
+run_test() {
+    cleanup "${ENCRYPTED_PATH}"
+
+    # Poorman's synchronisation; giving test-data-generator service (create_test_files) a chance to complete.
+    sleep 2
 
     # perform backup
     /app/entrypoint.sh backup
 
-    # if s3sync is enabled, then remove local encrypted files so that they are pulled down from S3, during restore
-    # attempts below
-    if s3sync is_enabled; then
-        rm -f "${ENCRYPTED_PATH}/"*.txt.gpg
-    fi
-
-    # restore each file
-    for i in $(seq 1 5); do
-        local filepath="${SOURCE_PATH}/data-$(printf %02d $i).txt"
-        local filename=$(basename "$filepath")
-
-        if is_number "$SOURCE_REMOVE_PLAIN" && [ "$SOURCE_REMOVE_PLAIN" -eq 1 ]; then
-            bail_file_exists "$filepath";
+    # Verify that SOURCE_REMOVE_PLAIN option takes effect
+    for i in $(seq 1 "$n_files"); do
+        local filepath="${SOURCE_PATH}/data-$(printf '%02d' "$i").txt"
+        if [ "$SOURCE_REMOVE_PLAIN" = 1 ]; then
+            bail_file_exists "$filepath"
+        else
+            bail_file_not_exists "$filepath"
         fi
-
-        /app/entrypoint.sh restore "${filename}.gpg"
-        verify_test_file "$filename"
     done
 
-    # Using the last file from the above set of tests, which has already been restored into SOURCE_PATH, check if the
-    # restore will fail if the destination file already exists. If the command succeeds, i.e the file was overwritten,
-    # then it is treated as a failure.
-    if /app/entrypoint.sh restore "data-01.txt.gpg"; then
-        error "File in SOURCE_PATH overwritten!"
-        return 1;
+    # Restore each file only if the SOURCE_PATH is writable.
+    # SOURCE_PATH can be made read-only via settings given to volume options
+    # This test makes sure that gpg-s3sync honours these and does not fall apart.
+    if [ -w "${SOURCE_PATH}" ]; then
+        for i in $(seq 1 "$n_files"); do
+            local filepath="${SOURCE_PATH}/data-$(printf '%02d' "$i").txt"
+            local filename=$(basename "$filepath")
+
+            # remove the file before restore; otherwise 'restore' will bail seeing the file
+            rm -f "$filepath";
+
+            # if s3sync is enabled, then remove local encrypted files so that they are pulled down from S3, during
+            # restore attempts below
+            if s3sync is_enabled; then
+                rm -f "${ENCRYPTED_PATH}/"*.txt.gpg
+            fi
+
+            # restore the specific file
+            /app/entrypoint.sh restore "${filename}.gpg"
+            verify_test_file "$filename"
+        done
+
+        # Using one file from the above set of tests, which has already been restored into SOURCE_PATH, check if the
+        # restore will fail if the destination file already exists. If the command succeeds, i.e the file was
+        # overwritten, then it is treated as a failure.
+        if /app/entrypoint.sh restore "data-01.txt.gpg"; then
+            error "File in SOURCE_PATH overwritten!"
+            return 1;
+        fi
     fi
 
     return 0;
 }
 
-run
+cmd="$1"; shift
+case "$cmd" in
+    wait)
+        while true; do sleep 1; done;
+        ;;
+    run_test|create_test_files|cleanup)
+        "$cmd" "$@"
+        ;;
+    *)
+        bail "Unknown command '$cmd'"
+        ;;
+esac


### PR DESCRIPTION
- No "data-paths" will be created in the image, in order to stop docker from mucking up permissions
- gpg-s3sync will now check all paths that it works with to make sure it can proceed effectively; if not it bails with descriptive error
- data-generateor split out into a seperate docker file and as a new service in `docker-compose.test.yml`, in order to emulate a real data generation service
- various improvements to the test script
- Added extra docker-ignores